### PR TITLE
Run linters and tests on every push on Github Actions

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -1,0 +1,20 @@
+name: Test and lint
+on:
+  push:
+  pull_request:
+
+jobs:
+  test-and-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: build
+      run: |
+        make build
+    - name: lint
+      run: |
+        make style-check
+    - name: test
+      run: |
+        make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-APP_VERSION=$(shell docker-compose run app poetry version --short)
+APP_VERSION=$(shell docker compose run app poetry version --short)
 INSTALLER_FILE_NAME="alinka-$(APP_VERSION).deb"
 
 .PHONY: build
@@ -8,36 +8,36 @@ help: ## Show this help
 
 
 test: ## Run all unit tests
-	docker-compose -f docker-compose.test.yml run --rm app pytest
+	docker compose -f docker-compose.test.yml run --rm app pytest
 
 name=
 test-case: ## Run single test unit
-	docker-compose -f docker-compose.test.yml run --rm app pytest -k ${name}
+	docker compose -f docker-compose.test.yml run --rm app pytest -k ${name}
 
 build: ## Build docker image
-	docker-compose build --no-cache
+	docker compose build --no-cache
 
 run: ## Run application
-	docker-compose up
+	docker compose up
 
 type=specjalne
 generate: ## Generate documents. Use `type=` params to create given type of document.
-	docker-compose run --rm app python alinka/create_documents.py --type ${type}
+	docker compose run --rm app python alinka/create_documents.py --type ${type}
 
 populate_schools: ## Populate school db table with fixtures
-	docker-compose run app python alinka/scripts.py
+	docker compose run app python alinka/scripts.py
 
 style: ## Run black, isort, flake8 linters
-	docker-compose run --rm app bash -c "black . && isort . && flake8 ."
+	docker compose run --rm app bash -c "black . && isort . && flake8 ."
 
 style-check:
-	docker-compose run --rm app bash -c "black . --check && isort . --check && flake8 ."
+	docker compose run --rm app bash -c "black . --check && isort . --check && flake8 ."
 
 installer: ## Create installer
-	docker-compose run --rm -u root app rm -rf dist/ build/ package/ $(INSTALLER_FILE_NAME)
-	docker-compose run --rm -u root app pyinstaller alinka.spec --noconfirm
-	docker-compose run --rm -u root app ./package.sh
-	docker-compose run --rm -u root app fpm -v $(APP_VERSION) -p $(INSTALLER_FILE_NAME)
+	docker compose run --rm -u root app rm -rf dist/ build/ package/ $(INSTALLER_FILE_NAME)
+	docker compose run --rm -u root app pyinstaller alinka.spec --noconfirm
+	docker compose run --rm -u root app ./package.sh
+	docker compose run --rm -u root app fpm -v $(APP_VERSION) -p $(INSTALLER_FILE_NAME)
 
 installer-name: ## Display name of installer of current version of app
 	@echo $(INSTALLER_FILE_NAME)


### PR DESCRIPTION
Docker compose part is caused by unavailability of legacy Docker Compose on Github Actions workers.
For more context, see: https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/

Passing pipeline can be seen on my fork: https://github.com/magul/alinka-pyside/commit/cc386ecbbe66ddfd84aef7448a6c327b0fb9266a (as we haven't yet merge that pipeline to main repository, it will not run it in here).