### PR TITLE
Fix way parent attributes work + stop swallowing Exceptions

### DIFF
--- a/alinka/widget/containers/main_body/footer/application.py
+++ b/alinka/widget/containers/main_body/footer/application.py
@@ -23,26 +23,16 @@ class ApplicationFooterContainer(QFrame):
 
     @property
     def document_data(self):
-        return self.parent.parent.content_container.application_container.document_data
+        return self.parent.parent().content_container.application_container.document_data
 
     def validate_document_data(self) -> None:
         if not get_support_center_data():
             raise ValidationError()
 
     def print_documents(self) -> None:
-        try:
-            self.validate_document_data()
-            generate_and_save_decision(form_data=self.document_data, generate=True)
-        except Exception:
-            # to decide how we want handle this exception in separate ticket
-            # on handling exceptions
-            pass
+        self.validate_document_data()
+        generate_and_save_decision(form_data=self.document_data, generate=True)
 
     def save_document_data(self) -> None:
-        try:
-            self.validate_document_data()
-            generate_and_save_decision(form_data=self.document_data, generate=False)
-        except Exception:
-            # to decide how we want handle this exception in separate ticket
-            # on handling exceptions
-            pass
+        self.validate_document_data()
+        generate_and_save_decision(form_data=self.document_data, generate=False)

--- a/alinka/widget/containers/main_body/footer/settings/support_center_tab.py
+++ b/alinka/widget/containers/main_body/footer/settings/support_center_tab.py
@@ -16,7 +16,7 @@ class SettingsSupportCenterDataContainer(QFrame):
 
     @property
     def support_center_data(self) -> SupportCenterData:
-        return self.parent.parent.parent.content_container.settings_container.support_center_data
+        return self.parent().parent().parent().content_container.settings_container.support_center_data
 
     def save_support_center_data(self) -> None:
         support_center_data = SupportCenterDbSchema(**self.support_center_data.model_dump())


### PR DESCRIPTION
I haven't yet checked whether this is PySide6 upgrade regression, or whether that never worked, but with changes from this pull request I was able to: 1) save support center and 2) print document (just be aware, that we validated some data, but don't inform user in Qt window, what's wrong - instead of that we just print `ValidationError` inside console, which by default we hide; we should start showing errors somehow to our endusers)