### PR TITLE
140 - Prevent from adding duplicated rspo schools

### DIFF
--- a/alinka/db/models.py
+++ b/alinka/db/models.py
@@ -1,4 +1,12 @@
-from sqlalchemy import Boolean, Column, Date, DateTime, Integer, String
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects.sqlite import JSON
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.sql import func
@@ -86,6 +94,8 @@ class School(Base):
     town = Column(String(128), nullable=False)
     postal_code = Column(String(12), nullable=False)
     post = Column(String(128), nullable=False)
+
+    __table_args__ = (UniqueConstraint("rspo_id", name="uq_school_rspo_id"),)
 
 
 class SupportCenter(Base):

--- a/alinka/widget/containers/main_body/footer/settings/schools_tab.py
+++ b/alinka/widget/containers/main_body/footer/settings/schools_tab.py
@@ -1,4 +1,5 @@
 from PySide6.QtWidgets import QFrame, QHBoxLayout, QPushButton, QWidget
+from sqlalchemy.exc import IntegrityError
 
 from alinka.db.queries import create_school
 
@@ -15,11 +16,21 @@ class SettingsSchoolsContainer(QFrame):
         add_remove_applicant_btn.clicked.connect(self.add_school)
         layout.addWidget(add_remove_applicant_btn)
 
-    def add_school(self):
+    def add_school(self) -> None:
         content_container = self.settings_footer_container.footer_container.main_body_container.content_container
         school_tab_container = content_container.settings_container.schools_tab_container
 
-        create_school(
-            school_tab_container.school_data_group.school_data.model_dump(exclude=("full_address", "description"))
-        )
+        try:
+            create_school(
+                school_tab_container.school_data_group.school_data.model_dump(exclude=("full_address", "description"))
+            )
+        except IntegrityError:
+            header_container = self.settings_footer_container.footer_container.main_body_container.header_container
+            header_container.set_error_message("Szkoła o podanym numerze RSPO już istnieje.")
+            content_container = self.settings_footer_container.footer_container.main_body_container.content_container
+            school_data_group = content_container.settings_container.schools_tab_container.school_data_group
+            # we need to clear the form after showing the error message
+            school_data_group.clear()
+            return
+
         school_tab_container.school_list.refresh()

--- a/migrations/versions/2025_09_14_1335_unique_rspo_school_4661708a4685.py
+++ b/migrations/versions/2025_09_14_1335_unique_rspo_school_4661708a4685.py
@@ -1,0 +1,48 @@
+"""unique_rspo_school
+
+Revision ID: 4661708a4685
+Revises: 8efed76c37b5
+Create Date: 2025-09-14 13:35:19.176507
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4661708a4685"
+down_revision: Union[str, None] = "8efed76c37b5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM school
+            WHERE id NOT IN (
+                SELECT MIN(id)
+                FROM school
+                WHERE rspo_id IS NOT NULL
+                GROUP BY rspo_id
+            )
+            AND rspo_id IS NOT NULL
+            AND rspo_id IN (
+                SELECT rspo_id FROM school
+                WHERE rspo_id IS NOT NULL
+                GROUP BY rspo_id
+                HAVING COUNT(*) > 1
+            )
+            """
+        )
+    )
+    with op.batch_alter_table("school", schema=None) as batch_op:
+        batch_op.create_unique_constraint("uq_school_rspo_id", ["rspo_id"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("school", schema=None) as batch_op:
+        batch_op.drop_constraint("uq_school_rspo_id", type_="unique")


### PR DESCRIPTION
* migracja - usunięcie szkół duplikatów
* migracja - dodanie indeksu unique dla kolumny `rspo_id` - zob. https://www.sqlitetutorial.net/sqlite-unique-constraint/
* obsługa błędu gdy tworzony jest duplikat (wyświetla komunikat, czyści formularz z danymi szkoły)
closes #140 