### PR TITLE
Poprawa pipilenów budowania

### DIFF
--- a/.github/workflows/_build-win.yml
+++ b/.github/workflows/_build-win.yml
@@ -40,7 +40,8 @@ jobs:
       run: |
         Invoke-WebRequest -Uri "https://www.jrsoftware.org/download.php/is.exe" -OutFile "C:\InnoSetupInstaller.exe"
         Start-Process "C:\InnoSetupInstaller.exe" -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART" -Wait
-        $env:Path += ";C:\Program Files (x86)\Inno Setup 6"
+        $env:PATH += ";C:\Program Files (x86)\Inno Setup 6"
+        "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: build PyInstaller package
       run: |
         poetry run pyinstaller alinka.spec --noconfirm

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV QT_DEBUG_PLUGINS=0
 ENV DEBIAN_FRONTEND=noninteractive
 # This fix: libGL error: No matching fbConfigs or visuals found
 ENV LIBGL_ALWAYS_INDIRECT=1
-ENV PATH="${PATH}:/root/.gem/ruby/3.1.0/bin:/root/.local/share/gem/ruby/3.1.0/bin"
+ENV PATH="${PATH}:/root/.gem/ruby/3.3.0/bin:/root/.local/share/gem/ruby/3.3.0/bin"
 
 RUN apt-get update && apt-get install -y build-essential python3-pip python3-dev libxcb-cursor0 qt6-base-dev ruby && \
     gem install fpm --user-install && \


### PR DESCRIPTION
Mieliśmy 2 problemy:
 * Debian - 12 sierpnia 2025 obraz dockerowy python:3.12-slim zaczął korzystać z Debiana Trixie zamiast z Debian Bookworm (link: https://github.com/docker-library/official-images/commit/47a7ce01c57f3e08f6c22fe9d22980e914140df1);
   W Debianie Trixie zamiast Ruby 3.1 jest dostępne Ruby 3.3

 * Windows - 2 września 2025 GitHub Action runner windows-latest został przepięty z Windows Server 2022 na Windows Server 2025; wygląda na to, że Inno Setup 6 był pre-instalowany w Windows Sever 2022 (przez co krok install Inno Setup 6 nie był potrzebny i jednoczesnie był niekompletny: https://github.com/CodeForPoznan/alinka-pyside/blob/c934b01f674ce1233d4663d06132816f0173db9f/.github/workflows/_build-win.yml#L38-L43),
   za to Windows Server 2025 nie posiada Inno Setup 6 (link:
https://github.com/actions/runner-images/issues/11644), co ujawniło
   niekompletność kroku jego instalacji (zawsze musieliśmy zapisac do
   GITHUB_ENV nową wartość PATH, ale nie zauważaliśmy tego problemu
   bo Inno Setup 6 był preinstalowany).