### PR TITLE
[126] Dodanie /package do wykluczeń stylowania kodu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ exclude = '''
   | \.venv
   | build
   | dist
+  | package
 )/
 '''
 


### PR DESCRIPTION
Installer używa `dist/ build/ package/`, w konfiguracji stylowania (`make style`) brakowało tej ścieżki z wykluczeń. 

Resolves #126 