### PR TITLE
Dodanie zmiennych środowiskowych i wolumenu odpowiedzialnych

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Alinka PySide
 
-## Development
-
-If you're using Docker Compose (or Linux in general) for development, be aware
-that Waylaynd as Windows System is causing issues and it would be wise
-to switch X11 (see procedure in https://apploye.com/help/switch-from-wayland-to-xorg-ubuntu/).
-
 ## Release 
 To make a release please follow instruction
 1. Go to "Actions" tab and run "Crate release" workflow (additional instructions [here](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow#running-a-workflow)).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,11 @@
 services:
   app:
     environment:
-      - DISPLAY=$DISPLAY
+    # X11 (legacy)
+    - DISPLAY=$DISPLAY
+    # Wayland
+    - XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
+    - WAYLAND_DISPLAY=$WAYLAND_DISPLAY
     container_name: alinka-linux
     build:
       context: .
@@ -10,9 +14,14 @@ services:
     command: python run.py
 
     volumes:
-      - ".:/app/"
-      - "/tmp/.X11-unix:/tmp/.X11-unix"
-      - "./.volumes/data:/home/qtuser/.local/share/Alinka"
-      - "./.volumes/documents:/home/qtuser/Documents/Alinka"
+    # source code
+    - ".:/app/"
+    # X11 (legacy)
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
+    # Wayland
+    - "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}"
+    # data
+    - "./.volumes/data:/home/qtuser/.local/share/Alinka"
+    - "./.volumes/documents:/home/qtuser/Documents/Alinka"
 
     user: qtuser


### PR DESCRIPTION
za wspóldzielenie serwera wyświetlania Wayland między hostem Linuksowym a kontenerem Dockerowym.

(Kontekst: Ubunt 25.10 usunęło zupełnie wsparcie dla Gnome na X11, więcej:
https://discourse.ubuntu.com/t/ubuntu-25-10-drops-support-for-gnome-on-xorg/62538)
