### PR TITLE
142 Validate team member data before save

### DIFF
--- a/alinka/schemas/db_schema.py
+++ b/alinka/schemas/db_schema.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class BaseDbSchema(BaseModel):
@@ -96,8 +96,8 @@ class SupportCenterDbSchema(BaseDbSchema):
 
 
 class TeamMemberDbCreateSchema(BaseDbSchema):
-    name: str
-    function: str
+    name: str = Field(..., min_length=1)
+    function: str = Field(..., min_length=1)
 
 
 class TeamMemberDbSchema(TeamMemberDbCreateSchema):

--- a/alinka/widget/containers/main_body/content/settings/settings_tabs/team_member_tab/team_member_table_group.py
+++ b/alinka/widget/containers/main_body/content/settings/settings_tabs/team_member_tab/team_member_table_group.py
@@ -81,7 +81,10 @@ class TeamMemberTableModel(QAbstractTableModel):
 
         tm_dict = {k: self.data(index.siblingAtColumn(i)) for i, k in enumerate(self.columns)}
         tm_dict[self.columns[index.column()]] = value
-        tm = TeamMemberDbSchema.model_validate(tm_dict)
+        try:
+            tm = TeamMemberDbSchema.model_validate(tm_dict)
+        except ValidationError:
+            return False
         upsert_team_members([tm])
 
         self.dataChanged.emit(index, index)


### PR DESCRIPTION
Wcześniej przed zapisem model wysyłał `""` do db, co przechodziło walidację.

closes #142 