### PR TITLE
Fix validation message display for MeetingMemberGroup

### DIFF
--- a/alinka/widget/containers/main_body/content/application/application_tabs/meeting_tab/__init__.py
+++ b/alinka/widget/containers/main_body/content/application/application_tabs/meeting_tab/__init__.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
     QSizePolicy,
     QVBoxLayout,
     QWidget,
+    QLabel,
 )
 
 from alinka.db.queries import (
@@ -233,6 +234,12 @@ class MeetingMemberGroup(ValidationMixin, QGroupBox):
         self.handle_member_frame = HandleMemberFrame(self)
         self.handle_member_frame.team_member_changed.connect(self.populate_meeting_members)
 
+        # Label for error message
+        self.error_label = QLabel("", self)
+        self.error_label.setStyleSheet("color: red; font-size: 12px;")
+        self.error_label.setVisible(False)
+        layout.addWidget(self.error_label)
+
         layout.addWidget(self.listView, 0)
         layout.addWidget(self.handle_member_frame)
 
@@ -292,16 +299,25 @@ class MeetingMemberGroup(ValidationMixin, QGroupBox):
         return None
 
     def display_validation_result(self, validation_result: bool):
-        if validation_result:
-            self.listView.setProperty("validationState", "invalid")
-        else:
-            self.listView.setProperty("validationState", "valid")
+        state = "valid" if validation_result else "invalid"
+        self.listView.setProperty("validationState", state)
         self.listView.style().unpolish(self.listView)
         self.listView.style().polish(self.listView)
 
+        style = "" if validation_result else "border: 1px solid red;"
+        self.listView.setStyleSheet(style)
+
+        if validation_result:
+            self.error_label.setVisible(False)
+            self.error_label.setText("")
+        else:
+            self.error_label.setVisible(True)
+            self.error_label.setText(self.error_message or "")
+
     def validate(self) -> bool:
-        self.display_validation_result(self.is_valid)
-        return self.is_valid
+        valid = self.is_valid
+        self.display_validation_result(valid)
+        return valid
 
     def clear_validation_state(self):
         self.listView.setProperty("validationState", "")
@@ -338,7 +354,7 @@ class MeetingTabContainer(ValidationMixin, QWidget):
         self.meeting_member_group.populate_meeting_members()
 
         # Collect all components for validation
-        self.components = [self.meeting_datetime_frame, self.meeting_leader]
+        self.components = [self.meeting_datetime_frame, self.meeting_member_group, self.meeting_leader]
 
     def meeting_member_selection_changed(self) -> None:
         self.meeting_leader.combobox.clear()
@@ -360,7 +376,7 @@ class MeetingTabContainer(ValidationMixin, QWidget):
         return None
 
     def validate(self) -> bool:
-        results = [c.validate() for c in [self.meeting_datetime_frame, self.meeting_member_group, self.meeting_leader]]
+        results = [c.validate() for c in self.components]
         return all(results)
 
     def clear_validation_state(self):

--- a/alinka/widget/containers/main_body/content/application/application_tabs/meeting_tab/__init__.py
+++ b/alinka/widget/containers/main_body/content/application/application_tabs/meeting_tab/__init__.py
@@ -309,7 +309,6 @@ class MeetingMemberGroup(ValidationMixin, QGroupBox):
 
         if validation_result:
             self.error_label.setVisible(False)
-            self.error_label.setText("")
         else:
             self.error_label.setVisible(True)
             self.error_label.setText(self.error_message or "")

--- a/alinka/widget/containers/main_body/content/application/application_tabs/meeting_tab/__init__.py
+++ b/alinka/widget/containers/main_body/content/application/application_tabs/meeting_tab/__init__.py
@@ -5,12 +5,12 @@ from PySide6.QtWidgets import (
     QFrame,
     QGroupBox,
     QHBoxLayout,
+    QLabel,
     QListView,
     QPushButton,
     QSizePolicy,
     QVBoxLayout,
     QWidget,
-    QLabel,
 )
 
 from alinka.db.queries import (

--- a/alinka/widget/containers/main_body/footer/application.py
+++ b/alinka/widget/containers/main_body/footer/application.py
@@ -48,15 +48,17 @@ class ApplicationFooterContainer(QFrame):
         self.content_container.show_browser_container()
         self.footer_container.show_browser_footer_container()
 
-    def validate_document_data(self) -> None:
+    def validate_document_data(self) -> bool:
         if not self.content_container.validate_basic_settings():
             error_message = self.content_container.settings_container.error_message
             show_validation_error(self, error_message)
-            return
+            return False
         if not self.content_container.validate_application():
             error_message = self.content_container.application_container.error_message
             show_validation_error(self, error_message)
-            return
+            return False
+
+        return True
 
     def print_documents(self) -> None:
         application_container = self.content_container.application_container


### PR DESCRIPTION
Previously, the validation message for `MeetingMemberGroup` (requiring at least two team members) was returned correctly as `False`, but the error text was not displayed in the form. Users only saw a generic invalid tab indicator on the "Zespół" tab.

This change ensures that:

* The error message is displayed directly under the "Członkowie zespołu" label, above the list.
* The list retains full interactivity while highlighting the validation state.
* Users clearly see what needs to be corrected without relying solely on the tab-level error.


<img width="1573" height="746" alt="obraz" src="https://github.com/user-attachments/assets/f5dd51ba-87e1-4d52-9f3a-8ec4b7f98214" />
