### PR TITLE
Add issue templates and exclude .claude from git

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Coś nie działa jak powinno — regresja lub błędne zachowanie
+title: ""
+labels: ["bug"]
+body:
+  - type: textarea
+    id: repro
+    attributes:
+      label: Kroki reprodukcji
+      description: Jak możemy odtworzyć ten błąd krok po kroku?
+      placeholder: |
+        1. Otwórz aplikację
+        2. Przejdź do...
+        3. Kliknij...
+        4. Widzisz błąd
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Oczekiwane zachowanie
+      description: Co powinno się stać?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Aktualne zachowanie
+      description: Co się faktycznie dzieje? Jeśli jest komunikat błędu — wklej go tutaj.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Środowisko
+      placeholder: |
+        - OS: Windows 11 / Ubuntu 22.04 / macOS 14
+        - Wersja Alinki: x.x.x
+    validations:
+      required: true
+
+  - type: textarea
+    id: extras
+    attributes:
+      label: Zrzuty ekranu / logi
+      description: Opcjonalnie — screenshot, nagranie lub fragment logu z konsoli.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,47 @@
+name: Chore
+description: Praca techniczna bez wartości dla użytkownika — porządki, refactor, upgrade zależności
+title: ""
+labels: ["chore"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: Co trzeba zrobić?
+      description: Konkretny opis pracy do wykonania.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Dlaczego teraz?
+      description: Co motywuje to zadanie? Co się psuje lub pogarsza jeśli tego nie zrobimy?
+      placeholder: |
+        Np. "Dependabot zgłasza lukę w X", "refactor potrzebny zanim dodamy Y",
+        "dług techniczny który spowalnia każdą zmianę w module Z"
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Zakres
+      description: Co jest w scope, a co nie — żeby zadanie nie rosło w trakcie.
+      placeholder: |
+        W scope:
+        - ...
+
+        Poza scope:
+        - ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: dod
+    attributes:
+      label: Kryteria ukończenia
+      description: Skąd wiemy że sprzątanie jest zrobione?
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/discovery.yml
+++ b/.github/ISSUE_TEMPLATE/discovery.yml
@@ -1,0 +1,55 @@
+name: Discovery
+description: Nie wiemy jeszcze jak to zrobić — issue wymaga zbadania przed implementacją
+title: ""
+labels: ["discovery"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Discovery zamykamy gdy mamy odpowiedź na pytanie i gotowe issue/y z konkretnym zadaniem do implementacji.
+        Samo discovery **nie kończy się kodem** — kończy się decyzją i planem.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Pytanie do odpowiedzenia
+      description: Jedno konkretne pytanie, na które to discovery ma odpowiedzieć.
+      placeholder: "Jak powinniśmy obsłużyć X? / Czy Y jest możliwe w naszym stacku? / Którą z opcji A/B/C wybrać i dlaczego?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Kontekst
+      description: Dlaczego to pytanie jest ważne? Co blokuje lub motywuje to zadanie?
+    validations:
+      required: true
+
+  - type: textarea
+    id: options
+    attributes:
+      label: Znane opcje / podejścia
+      description: Co już wiemy? Jakie opcje wchodzą w grę?
+    validations:
+      required: false
+
+  - type: textarea
+    id: resources
+    attributes:
+      label: Zasoby / linki
+      description: Dokumentacja, podobne projekty, wcześniejsze dyskusje, PR-y.
+    validations:
+      required: false
+
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Kiedy to discovery można zamknąć?
+      placeholder: |
+        - [ ] Wiemy którą opcję wybieramy i dlaczego
+        - [ ] Decyzja jest udokumentowana w komentarzu do tego issue
+        - [ ] Powstały issue/y z konkretnym zadaniem implementacyjnym (lub świadomie zdecydowaliśmy że nie implementujemy)
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Nowa funkcjonalność lub rozszerzenie istniejącej
+title: ""
+labels: ["feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / potrzeba
+      description: Jaki problem rozwiązuje ta funkcjonalność? Dla kogo?
+      placeholder: "Jako [typ użytkownika] chcę [zrobić X], żeby [osiągnąć Y]."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proponowane rozwiązanie
+      description: Jak to powinno wyglądać lub działać? Możesz dołączyć mockup lub opis przepływu.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Poza zakresem
+      description: Co NIE jest częścią tego zadania? Wpisz wprost, żeby uniknąć scope creep podczas implementacji.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Kryteria akceptacji
+      description: Skąd wiemy że zadanie jest skończone?
+      placeholder: |
+        - [ ] Użytkownik może...
+        - [ ] Dane są zapisywane gdy...
+        - [ ] Edge case X jest obsłużony
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/template_comparison.yml
+++ b/.github/ISSUE_TEMPLATE/template_comparison.yml
@@ -1,0 +1,55 @@
+name: Porównanie szablonu dokumentu
+description: Aktualizacja szablonu DOCX do nowego wzorca MEN — użyj gdy wychodzi nowe rozporządzenie
+title: "Porównanie istniejącej template \"[NAZWA]\" do nowego wzorca"
+labels: ["discovery", "templates"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Użyj tego szablonu gdy Ministerstwo Edukacji wydało nowe rozporządzenie i trzeba zaktualizować istniejący szablon DOCX generowany przez Alinkę.
+
+  - type: textarea
+    id: legal_context
+    attributes:
+      label: Kontekst prawny
+      description: Rozporządzenie, numer Dz.U., załącznik którego dotyczy zadanie.
+      placeholder: |
+        Rozporządzenie MEN z dnia [DATA] (Dz. U. z [ROK] r. poz. [NR])
+        Załącznik nr [X] — [NAZWA DOKUMENTU]
+    validations:
+      required: true
+
+  - type: input
+    id: wzorzec_url
+    attributes:
+      label: Link do nowego wzorca
+      description: Bezpośredni link do PDF lub strony z rozporządzeniem.
+      placeholder: "https://..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: changes
+    attributes:
+      label: Zakres zmian względem poprzedniego wzorca
+      description: Co się zmieniło? Pogrupuj na zmiany tekstowe i strukturalne.
+      placeholder: |
+        Zmiany tekstowe (zaktualizowane podstawy prawne, brzmienie pól, itp.):
+        - ...
+
+        Zmiany strukturalne (nowe sekcje, zmieniony układ, usunięte pola, itp.):
+        - ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Kiedy zadanie można uznać za skończone?
+      placeholder: |
+        - [ ] Szablon Jinja2 zaktualizowany zgodnie z nowym wzorcem
+        - [ ] Wygenerowany dokument porównany ręcznie z wzorcem MEN (wizualnie i treściowo)
+        - [ ] Testy generowania dokumentu przechodzą
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/template_comparison.yml
+++ b/.github/ISSUE_TEMPLATE/template_comparison.yml
@@ -1,6 +1,6 @@
 name: Porównanie szablonu dokumentu
 description: Aktualizacja szablonu DOCX do nowego wzorca MEN — użyj gdy wychodzi nowe rozporządzenie
-title: "Porównanie istniejącej template \"[NAZWA]\" do nowego wzorca"
+title: "Porównanie istniejącego szablonu \"[NAZWA]\" do nowego wzorca"
 labels: ["discovery", "templates"]
 body:
   - type: markdown

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ help.spec
 *.db
 
 .idea/
+.vscode/
+.tmp_*/
+*.code-workspace
+.claude/


### PR DESCRIPTION
## Summary

- Dodaje pięć szablonów YAML do `.github/ISSUE_TEMPLATE/`: `bug_report`, `feature_request`, `discovery`, `template_comparison`, `chore`
- Każdy szablon automatycznie przypisuje właściwy label i wymusza minimalną strukturę (kroki repro, DoD, zakres)
- Dodaje `.claude/` do `.gitignore`

Closes #228

## Test plan

- [ ] Po otwarciu nowego issue na GitHub pojawia się wybór szablonu
- [ ] Każdy szablon otwiera się poprawnie i przypisuje właściwy label