### PR TITLE
Fix DOCX templates path in Windows bundle

### DIFF
--- a/alinka.spec
+++ b/alinka.spec
@@ -18,7 +18,7 @@ a = Analysis(
         ("alembic.ini", "."),
         ('migrations/env.py', 'migrations'),
         ('migrations/versions', 'migrations/versions'),
-        ('alinka/docx/templates', 'docx/templates')
+        ('alinka/docx/templates', 'alinka/docx/templates')
     ],
     hiddenimports=[
         # required by Alembic's env.py

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_pyinstaller_places_docx_templates_inside_docx_package():
+    spec_file = Path(__file__).parents[1] / "alinka.spec"
+
+    assert "('alinka/docx/templates', 'alinka/docx/templates')" in spec_file.read_text()


### PR DESCRIPTION
Changes the PyInstaller template destination to alinka/docx/templates and adds a regression test. Root cause: Jinja PackageLoader resolves templates relative to the alinka.docx package, but the Windows bundle placed them at docx/templates. Local pytest and PyInstaller could not run because this checkout has no usable Python or Poetry environment; Windows CI should validate the installer.