### PR TITLE
Fix DOCX bundle layout and Inno Setup installation

### DIFF
--- a/.github/workflows/_build-win.yml
+++ b/.github/workflows/_build-win.yml
@@ -38,8 +38,7 @@ jobs:
     - name: install Inno Setup 6
       shell: pwsh
       run: |
-        Invoke-WebRequest -Uri "https://www.jrsoftware.org/download.php/is.exe" -OutFile "C:\InnoSetupInstaller.exe"
-        Start-Process "C:\InnoSetupInstaller.exe" -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART" -Wait
+        winget install --id JRSoftware.InnoSetup --exact --source winget --accept-package-agreements --accept-source-agreements --silent
         $env:PATH += ";C:\Program Files (x86)\Inno Setup 6"
         "PATH=$env:PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: build PyInstaller package

--- a/alinka.spec
+++ b/alinka.spec
@@ -18,7 +18,7 @@ a = Analysis(
         ("alembic.ini", "."),
         ('migrations/env.py', 'migrations'),
         ('migrations/versions', 'migrations/versions'),
-        ('alinka/docx/templates', 'alinka/docx/templates')
+        ('alinka/docx/templates', 'docx/templates')
     ],
     hiddenimports=[
         # required by Alembic's env.py

--- a/alinka/docx/generate_document.py
+++ b/alinka/docx/generate_document.py
@@ -1,14 +1,19 @@
 import os
+import sys
 from zipfile import ZipFile
 
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, FileSystemLoader
 
 from alinka.constants import DocumentsTypes
 from alinka.schemas import DocumentData
 
-# Use PackageLoader so resources are resolved correctly from the installed package
-# (works with Windows installer and PyInstaller)
-loader = PackageLoader("alinka.docx", "templates")
+def get_templates_base_path() -> str:
+    if getattr(sys, "frozen", False):
+        return os.path.join(sys._MEIPASS, "docx", "templates")
+    return os.path.join(os.path.dirname(__file__), "templates")
+
+
+loader = FileSystemLoader(get_templates_base_path())
 environment = Environment(loader=loader)
 
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,7 +1,23 @@
+import os
 from pathlib import Path
 
+from alinka.docx import generate_document
 
-def test_pyinstaller_places_docx_templates_inside_docx_package():
+
+def test_pyinstaller_places_docx_templates_outside_executable_name():
     spec_file = Path(__file__).parents[1] / "alinka.spec"
 
-    assert "('alinka/docx/templates', 'alinka/docx/templates')" in spec_file.read_text()
+    assert "('alinka/docx/templates', 'docx/templates')" in spec_file.read_text()
+
+
+def test_templates_base_path_uses_pyinstaller_bundle_directory(monkeypatch):
+    monkeypatch.setattr(generate_document.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(generate_document.sys, "_MEIPASS", "C:/bundle", raising=False)
+
+    assert generate_document.get_templates_base_path() == os.path.join("C:/bundle", "docx", "templates")
+
+
+def test_windows_build_installs_inno_setup_from_winget():
+    workflow_file = Path(__file__).parents[1] / ".github" / "workflows" / "_build-win.yml"
+
+    assert "winget install --id JRSoftware.InnoSetup" in workflow_file.read_text()


### PR DESCRIPTION
Fixes the packaging regressions from PR #238. DOCX templates remain in docx/templates, outside the executable name collision, and the document generator uses FileSystemLoader with the PyInstaller bundle directory at runtime. The Windows workflow now installs Inno Setup through winget instead of executing a corrupted direct download. Adds regression coverage for the bundle layout, frozen template path, and workflow installation method. Local pytest/PyInstaller could not run because Docker is unavailable on this machine; GitHub Actions must validate the full build.